### PR TITLE
Add Typescript type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,8 +34,8 @@ export interface BenchResultsType extends ComputedResult {
 }
 
 export interface BenchmarkProps {
-    component: ComponentType;
-    componentProps?: {};
+    component: ComponentType<any>;
+    componentProps?: any;
     includeLayout?: boolean;
     onComplete: (res: BenchResultsType) => void;
     samples: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,52 @@
+import { ComponentType, ForwardRefExoticComponent, RefAttributes } from 'react';
+
+export const BenchmarkType: {
+    MOUNT: 'mount';
+    UPDATE: 'update';
+    UNMOUNT: 'unmount';
+};
+
+export interface Sample {
+    start: number;
+    end: number;
+    elapsed: number;
+    layout: number;
+}
+
+export interface ComputedResult {
+    max: number;
+    min: number;
+    median: number;
+    mean: number;
+    stdDev: number;
+    p70: number;
+    p95: number;
+    p99: number;
+}
+
+export interface BenchResultsType extends ComputedResult {
+    startTime: number;
+    endTime: number;
+    runTime: number;
+    sampleCount: number;
+    samples: Sample[];
+    layout?: ComputedResult;
+}
+
+export interface BenchmarkProps {
+    component: ComponentType;
+    componentProps?: {};
+    includeLayout?: boolean;
+    onComplete: (res: BenchResultsType) => void;
+    samples: number;
+    timeout?: number;
+    type: typeof BenchmarkType[keyof typeof BenchmarkType];
+}
+
+export interface BenchmarkRef {
+    start: () => void;
+}
+
+declare const Benchmark: ForwardRefExoticComponent<BenchmarkProps & RefAttributes<BenchmarkRef>>;
+
+export default Benchmark;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A component utility for estimating benchmarks of React components",
   "main": "dist/cjs/index.js",
   "module": "dist",
+  "types": "index.d.ts",
   "author": "Paul Armstrong <paul@spaceyak.com>",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the react-component-bench project!
-->

# Problem

<!-- Explain the problem that this pull request aims to resolve. -->

No Typescript type declarations, it's not convenient to use this module in Typescript projects.

# Solution

<!-- Explain your approach. Sometimes it helps to justify your approach against some others that you didn't choose to explain why yours is better. -->

Just add it.

I created a type declaration file `index.d.ts` and provided these types:
- `BenchmarkType`
- `Sample`
- `ComputedResult`
- `BenchResultsType`
- `BenchmarkProps`
- `BenchmarkRef`
- `Benchmark`

# TODO

- [ ] Add & update tests
- [ ] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation and/or examples
